### PR TITLE
Add HTML demo for 9 bus analyzer

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,3 +15,7 @@ This repository contains a single React component that implements a simple load 
 
 The application does not include a backend; all calculations are mocked within the React component for demonstration purposes.
 
+
+## Running the Demo
+
+This repository now includes a simple `index.html` page that loads React from a CDN and renders the `LoadFlowCalculator` component. To try it out, open `index.html` in any modern web browser. No build step or server is required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>9 Bus System Analyzer</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-900">
+  <div id="root"></div>
+
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" data-presets="typescript,react" src="load_flow_calculator.tsx"></script>
+  <script type="text/babel" data-presets="typescript,react">
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<LoadFlowCalculator />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with CDN-based React setup
- document how to run the demo in `README.MD`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c76bf77848332b2c09985364456c4